### PR TITLE
fix(any-type): tolerate non-JSON strings and non-string values

### DIFF
--- a/lib/decorators/any-type.decorator.ts
+++ b/lib/decorators/any-type.decorator.ts
@@ -3,14 +3,22 @@ import { Transform } from 'class-transformer';
 export function AnyType({ isDto }: { isDto?: boolean } = {}) {
     return Transform((object) => {
         if (isDto && typeof object.value === 'string') {
-            return JSON.parse(object.value);
+            try {
+                return JSON.parse(object.value);
+            } catch {
+                return object.value;
+            }
         }
 
         if (object.options.groups?.includes('__sendData')) {
             return JSON.stringify(object.value);
         }
-        if (object.options.groups?.includes('__getData')) {
-            return JSON.parse(object.value);
+        if (object.options.groups?.includes('__getData') && typeof object.value === 'string') {
+            try {
+                return JSON.parse(object.value);
+            } catch {
+                return object.value;
+            }
         }
 
         return object.value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hodfords/nestjs-grpc-helper",
-    "version": "11.4.0-rc.36",
+    "version": "11.4.0-rc.37",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hodfords/nestjs-grpc-helper",
-            "version": "11.4.0-rc.36",
+            "version": "11.4.0-rc.37",
             "license": "UNLICENSED",
             "dependencies": {
                 "@faker-js/faker": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-grpc-helper",
-    "version": "11.4.0-rc.36",
+    "version": "11.4.0-rc.37",
     "description": "A utility for simplifying gRPC integration and communication in NestJS applications",
     "author": "",
     "license": "UNLICENSED",


### PR DESCRIPTION
## Summary

- Wrap both `JSON.parse(object.value)` calls in `AnyType` with a try/catch that falls back to the original value when parsing fails.
- Add a `typeof object.value === 'string'` guard to the `__getData` branch so already-deserialized payloads skip the parse entirely.

## Why

Caught in `employer-backend` after upgrading the activity microservice to `@hodfords/nestjs-grpc-helper@11.4.0-rc.36`. Without the fallback, payloads where `object.value` is either (a) a plain non-JSON string such as a UUID or display name, or (b) an already-parsed object/array, threw `SyntaxError` on the very first character and surfaced as 500 ISE.

Concrete impact before the fix: 8 of 24 e2e suites failed, 98 of 197 tests returned 500.

With this PR, the decorator parses when it can and passes the value through unchanged when it cannot, matching the pre-rc.36 behavior for the affected fields without losing the new JSON support.

## Test plan

- [x] `npm run build` — clean tsc build; generated JS is functionally identical to the patch we are running in production (only single-line vs multiline `} catch {` formatting differs).
- [x] Verified in `employer-backend` activity e2e: 24/24 suites and 197/197 tests pass with the patched JS this PR produces.
- [ ] Add a regression unit test for non-JSON / non-string `object.value` (left for follow-up unless you'd like it bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)