### PR TITLE
fix(any-type): guard __getData JSON.parse against non-string/non-JSON values

### DIFF
--- a/lib/decorators/any-type.decorator.ts
+++ b/lib/decorators/any-type.decorator.ts
@@ -10,7 +10,14 @@ export function AnyType({ isDto }: { isDto?: boolean } = {}) {
             return JSON.stringify(object.value);
         }
         if (object.options.groups?.includes('__getData')) {
-            return JSON.parse(object.value);
+            if (typeof object.value !== 'string') {
+                return object.value;
+            }
+            try {
+                return JSON.parse(object.value);
+            } catch {
+                return object.value;
+            }
         }
 
         return object.value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hodfords/nestjs-grpc-helper",
-  "version": "11.3.5",
+  "version": "11.3.6",
   "description": "A utility for simplifying gRPC integration and communication in NestJS applications",
   "author": "",
   "license": "UNLICENSED",


### PR DESCRIPTION
… values

AnyType's __getData transform is now also applied on the HTTP response path (nestjs-response optimize-response). The value there is already an object (or a plain string), so JSON.parse threw
'SyntaxError: "[object Object]" is not valid JSON' -> 500.

Pass non-strings through unchanged, and fall back to the raw string when JSON.parse fails, so JSON-encoded gRPC payloads still parse.

Bump 11.3.5 -> 11.3.6.