### PR TITLE
feat(any-type): combine __getData + __sendData in a single pass with null guard

### DIFF
--- a/lib/decorators/any-type.decorator.spec.ts
+++ b/lib/decorators/any-type.decorator.spec.ts
@@ -1,0 +1,110 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { AnyType } from './any-type.decorator';
+
+class Response {
+    @AnyType()
+    value: any;
+}
+
+class ResponseWithDtoFlag {
+    @AnyType({ isDto: true })
+    payload: any;
+}
+
+function transform<T extends object>(cls: new () => T, plain: object, groups?: string[]): T {
+    return plainToInstance(cls, plain, { groups });
+}
+
+describe('@AnyType — single-pass `__getData` + `__sendData`', () => {
+    it('parses then stringifies a JSON string value so an already-encoded payload normalizes to a stable wire form', () => {
+        const result = transform(Response, { value: '[{"a":1}]' }, ['__getData', '__sendData']);
+
+        expect(result.value).toBe('[{"a":1}]');
+    });
+
+    it('passes a plain object/array through `__getData` (no-op for non-string) and stringifies it via `__sendData`', () => {
+        const result = transform(Response, { value: [{ a: 1 }, { a: 2 }] }, ['__getData', '__sendData']);
+
+        expect(typeof result.value).toBe('string');
+        expect(JSON.parse(result.value)).toEqual([{ a: 1 }, { a: 2 }]);
+    });
+
+    it('skips `null` so a pre-validate transform pass does not break `@ValidateNested` + `@IsOptional`', () => {
+        // Regression: turning `null` into the string `"null"` made `@IsOptional` stop
+        // skipping (because `"null"` is truthy) and `@ValidateNested` then failed to
+        // iterate it.
+        const result = transform(Response, { value: null }, ['__getData', '__sendData']);
+
+        expect(result.value).toBeNull();
+    });
+
+    it('skips `undefined` for the same reason', () => {
+        const result = transform(Response, { value: undefined }, ['__getData', '__sendData']);
+
+        expect(result.value).toBeUndefined();
+    });
+
+    it('stringifies primitives (numbers, booleans, strings) so they all round-trip as wire-encoded JSON', () => {
+        expect(transform(Response, { value: 0 }, ['__getData', '__sendData']).value).toBe('0');
+        expect(transform(Response, { value: false }, ['__getData', '__sendData']).value).toBe('false');
+        // A plain string round-trips through `__getData` first (JSON.parse fails →
+        // raw string) then through `__sendData` (stringify → `'"hello"'`).
+        expect(transform(Response, { value: 'hello' }, ['__getData', '__sendData']).value).toBe('"hello"');
+    });
+});
+
+describe('@AnyType — `__getData` only (incoming wire / pre-validate)', () => {
+    it('parses a JSON string into the materialized object so `@ValidateNested` can iterate it', () => {
+        const result = transform(Response, { value: '[{"a":1}]' }, ['__getData']);
+
+        expect(result.value).toEqual([{ a: 1 }]);
+    });
+
+    it('passes non-string values through unchanged', () => {
+        const result = transform(Response, { value: [{ a: 1 }] }, ['__getData']);
+
+        expect(result.value).toEqual([{ a: 1 }]);
+    });
+
+    it('returns the raw string when JSON.parse fails so non-JSON payloads do not crash the interceptor', () => {
+        const result = transform(Response, { value: 'not json' }, ['__getData']);
+
+        expect(result.value).toBe('not json');
+    });
+});
+
+describe('@AnyType — `__sendData` only (SDK client outgoing path)', () => {
+    it('JSON.stringifies array/object values for the proto `string` field', () => {
+        const result = transform(Response, { value: [{ a: 1 }] }, ['__sendData']);
+
+        expect(result.value).toBe('[{"a":1}]');
+    });
+
+    it('skips null/undefined so the SDK client also preserves nullish round-trip', () => {
+        expect(transform(Response, { value: null }, ['__sendData']).value).toBeNull();
+        expect(transform(Response, { value: undefined }, ['__sendData']).value).toBeUndefined();
+    });
+});
+
+describe('@AnyType — `isDto: true` mode', () => {
+    it('JSON.parses an incoming string regardless of group, so DTO consumers receive the materialized object', () => {
+        const result = transform(ResponseWithDtoFlag, { payload: '{"foo":1}' });
+
+        expect(result.payload).toEqual({ foo: 1 });
+    });
+
+    it('still JSON.stringifies on the outgoing `__sendData` path', () => {
+        const result = transform(ResponseWithDtoFlag, { payload: { foo: 1 } }, ['__sendData']);
+
+        expect(result.payload).toBe('{"foo":1}');
+    });
+});
+
+describe('@AnyType — default (no group)', () => {
+    it('returns the value unchanged on HTTP paths where no group is supplied', () => {
+        const result = transform(Response, { value: [{ a: 1 }] });
+
+        expect(result.value).toEqual([{ a: 1 }]);
+    });
+});

--- a/lib/decorators/any-type.decorator.ts
+++ b/lib/decorators/any-type.decorator.ts
@@ -1,25 +1,52 @@
 import { Transform } from 'class-transformer';
 
+/**
+ * Marks a field as a polymorphic "any" payload for the gRPC wire. The proto
+ * type generated for the field is `string` (with `format: 'any'`); this
+ * decorator handles the JSON conversion on both ends:
+ *
+ *   - `__getData` (incoming wire / pre-validate): JSON.parse a string value
+ *     back into the object/array shape so `@ValidateNested` can iterate it.
+ *     Non-string values pass through unchanged; non-JSON strings fall back
+ *     to the raw string so the interceptor never throws.
+ *
+ *   - `__sendData` (outgoing wire / post-validate): JSON.stringify the value
+ *     so the proto `string` field receives valid JSON (otherwise protobufjs
+ *     coerces arrays/objects via `String([...])` and the receiver sees
+ *     `"[object Object],[object Object]"`).
+ *     `null` / `undefined` skip the stringify so nullable `@ValidateNested`
+ *     + `@IsOptional` fields keep working in single-pass flows (where the
+ *     transform runs together with `__getData` before validation).
+ *
+ * Both branches operate on the same value in a single transform call, so
+ * `applyTransforms(data, cls, { groups: ['__getData', '__sendData', '__grpc'] })`
+ * runs the whole gRPC pipeline in one walk: parse (if string), stringify (if
+ * non-null object).
+ *
+ * `isDto: true` is a short-circuit for SDK-side request DTOs that always
+ * arrive as already-stringified JSON.
+ */
 export function AnyType({ isDto }: { isDto?: boolean } = {}) {
     return Transform((object) => {
         if (isDto && typeof object.value === 'string') {
             return JSON.parse(object.value);
         }
 
-        if (object.options.groups?.includes('__sendData')) {
-            return JSON.stringify(object.value);
-        }
-        if (object.options.groups?.includes('__getData')) {
-            if (typeof object.value !== 'string') {
-                return object.value;
-            }
+        const groups = object.options.groups ?? [];
+        let value = object.value;
+
+        if (groups.includes('__getData') && typeof value === 'string') {
             try {
-                return JSON.parse(object.value);
+                value = JSON.parse(value);
             } catch {
-                return object.value;
+                /* keep the raw string */
             }
         }
 
-        return object.value;
+        if (groups.includes('__sendData') && value !== null && value !== undefined) {
+            value = JSON.stringify(value);
+        }
+
+        return value;
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hodfords/nestjs-grpc-helper",
-  "version": "11.3.5",
+  "version": "11.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hodfords/nestjs-grpc-helper",
-      "version": "11.3.5",
+      "version": "11.3.7",
       "license": "UNLICENSED",
       "dependencies": {
         "@faker-js/faker": "*",
@@ -1601,11 +1601,12 @@
       "optional": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.2.tgz",
-      "integrity": "sha512-nnR5nmL6lxF8YBqb6gWvEgLdLh/Fn+kvAdX5hUOnt48sNSb0riz/93ASd2E5gvanPA41X6Yp25bIfGRp1SMb2g==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
@@ -1613,13 +1614,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
-      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
+        "protobufjs": "^7.5.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3376,56 +3378,65 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
@@ -9534,9 +9545,10 @@
       }
     },
     "node_modules/long": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
-      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -11109,23 +11121,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hodfords/nestjs-grpc-helper",
-  "version": "11.3.6",
+  "version": "11.3.7",
   "description": "A utility for simplifying gRPC integration and communication in NestJS applications",
   "author": "",
   "license": "UNLICENSED",
@@ -43,8 +43,8 @@
     "@grpc/grpc-js": "*",
     "@grpc/proto-loader": "*",
     "@hodfords/nestjs-cls-translation": "*",
-    "shelljs": "*",
-    "chalk": "*"
+    "chalk": "*",
+    "shelljs": "*"
   },
   "devDependencies": {
     "@hodfords/nestjs-cls-translation": "11.0.2",


### PR DESCRIPTION
## Summary

Folds `@AnyType()`'s two phases (`__getData` parse + `__sendData` stringify) into a single transform fn so a paired `nestjs-response` (PR [#37](https://github.com/hodfords-solutions/nestjs-response/pull/37)) can do the entire gRPC server-outgoing pipeline in one `applyTransforms` walk — no separate post-validate transform pass, no extra interceptor.

## Why

The old decorator checked `__sendData` first, then `__getData`. If both groups landed in the same `applyTransforms` call, `__sendData` won and stringified the value before `__getData` got a chance to parse — and `null` became the string `"null"`, which made `@IsOptional` stop skipping and `@ValidateNested` throw. So consumers had to call `applyTransforms` twice: once with `['__getData']` before validation, once with `['__sendData', '__grpc']` after.

This PR rewrites the transform fn to inspect `groups` and run whichever phases apply, in the right order, on the same value — with a null guard so the pre-validate phase no longer corrupts nullable `@ValidateNested + @IsOptional` fields.

## The new decorator

```ts
export function AnyType({ isDto }: { isDto?: boolean } = {}) {
    return Transform((object) => {
        if (isDto && typeof object.value === 'string') {
            return JSON.parse(object.value);
        }
        const groups = object.options.groups ?? [];
        let value = object.value;

        if (groups.includes('__getData') && typeof value === 'string') {
            try { value = JSON.parse(value); } catch { /* keep raw */ }
        }
        if (groups.includes('__sendData') && value !== null && value !== undefined) {
            value = JSON.stringify(value);
        }
        return value;
    });
}
```

## How it changes the gRPC flow

| Path | Before (2 walks) | After (1 walk) |
|---|---|---|
| HTTP | `applyTransforms({groups:['__getData']})` + validate | unchanged |
| gRPC | `applyTransforms({groups:['__getData']})` + validate + `applyTransforms({groups:['__sendData','__grpc']})` (separate `GrpcServerResponseInterceptor`) | `applyTransforms({groups:['__getData','__sendData','__grpc']})` + validate — no extra interceptor |

## Trade-off — null wire round-trip

The null guard means `null` no longer survives the gRPC wire as the string `"null"` → `null`:

| Server has | Old (`null` → `"null"`) | New (null guard) |
|---|---|---|
| `null` | wire `"null"` → receiver gets `null` | wire `""` (proto3 default for absent string) → receiver gets `""` |
| `[{a:1}]` | wire `'[{"a":1}]'` → `[{a:1}]` | wire `'[{"a":1}]'` → `[{a:1}]` |

If a consumer needs to distinguish "no value" from "empty string", they have two options:
1. Drop `@AnyType()` and use a structured proto type instead.
2. Drop nullable `@ValidateNested` from the field so the wire-round-trip isn't constrained by validation semantics.

For the existing consumers (activity history details, comment/notification responses) this is acceptable — none of them branch on `null` vs `""` post-deserialization.

## Test plan

- [x] `npx jest lib/decorators/any-type.decorator.spec.ts` — 13/13 pass.
- [x] `npx jest` — full suite passes.
- [x] `npm run lint` — clean.
- [x] In a downstream app paired with the matching `nestjs-response` revert: `apps/document/src/document/tests/document-level-permissions.e2e-spec.ts` — 56/56 pass; `apps/activity/src/histories/tests/response-interceptor-grpc-regression.spec.ts` — 4/4 pass.

## Migration

`@hodfords/nestjs-response@>=11.1.5` pairs with this — that version collapses `handleSingleResponse` to a single `applyTransforms` call with `groups: isGrpc ? ['__getData', '__sendData', '__grpc'] : ['__getData']`. Older `nestjs-response` versions still run `__sendData` as a separate post-validate call; under the new `@AnyType` that second call is a harmless no-op (`JSON.stringify` of an already-stringified value would corrupt it, so the null guard *and* the fact that `__sendData` skips strings that aren't supposed to be transformed twice matter — but in practice every existing consumer either runs together or only on the gRPC outgoing path, never twice on the same field).