### PR TITLE
feat(any-type): backport single-pass + null guard to 11.4.x-rc (→ 11.4.0-rc.41)

### DIFF
--- a/lib/decorators/any-type.decorator.spec.ts
+++ b/lib/decorators/any-type.decorator.spec.ts
@@ -44,6 +44,54 @@ describe('AnyType', () => {
         expect(plain.data).toEqual({ keep: 'me' });
     });
 
+    describe('single-pass __getData + __sendData', () => {
+        it('parses a JSON string value and then re-stringifies it so an already-encoded payload normalizes to a stable wire form', () => {
+            const instance = plainToInstance(
+                AnyPayload,
+                { data: '[{"a":1}]' },
+                { groups: ['__getData', '__sendData'] }
+            );
+
+            expect(instance.data).toBe('[{"a":1}]');
+        });
+
+        it('leaves a plain object/array unchanged on __getData (non-string passes through) and stringifies it via __sendData', () => {
+            const instance = plainToInstance(
+                AnyPayload,
+                { data: [{ a: 1 }, { a: 2 }] },
+                { groups: ['__getData', '__sendData'] }
+            );
+
+            expect(typeof instance.data).toBe('string');
+            expect(JSON.parse(instance.data)).toEqual([{ a: 1 }, { a: 2 }]);
+        });
+    });
+
+    describe('null / undefined guard on __sendData', () => {
+        it('keeps null as null so a pre-validate transform pass does not break @ValidateNested + @IsOptional', () => {
+            // Regression: turning null into the string "null" made @IsOptional stop
+            // skipping (because "null" is truthy) and @ValidateNested then failed to
+            // iterate it.
+            const instance = plainToInstance(AnyPayload, { data: null }, { groups: ['__getData', '__sendData'] });
+
+            expect(instance.data).toBeNull();
+        });
+
+        it('keeps undefined as undefined for the same reason', () => {
+            const instance = plainToInstance(AnyPayload, { data: undefined }, { groups: ['__getData', '__sendData'] });
+
+            expect(instance.data).toBeUndefined();
+        });
+
+        it('still skips null when only __sendData is active (SDK client outgoing path)', () => {
+            const payload = new AnyPayload();
+            payload.data = null;
+
+            const plain = instanceToPlain(payload, { groups: ['__sendData'] });
+            expect(plain.data).toBeNull();
+        });
+    });
+
     describe('with isDto', () => {
         it('parses string values even without a transformation group', () => {
             const instance = plainToInstance(DtoPayload, { data: '{"a":1}' });

--- a/lib/decorators/any-type.decorator.ts
+++ b/lib/decorators/any-type.decorator.ts
@@ -1,25 +1,52 @@
 import { Transform } from 'class-transformer';
 
+/**
+ * Marks a field as a polymorphic "any" payload for the gRPC wire. The proto
+ * type generated for the field is `string` (with `format: 'any'`); this
+ * decorator handles the JSON conversion on both ends:
+ *
+ *   - `__getData` (incoming wire / pre-validate): JSON.parse a string value
+ *     back into the object/array shape so `@ValidateNested` can iterate it.
+ *     Non-string values pass through unchanged; non-JSON strings fall back
+ *     to the raw string so the interceptor never throws.
+ *
+ *   - `__sendData` (outgoing wire / post-validate): JSON.stringify the value
+ *     so the proto `string` field receives valid JSON (otherwise protobufjs
+ *     coerces arrays/objects via `String([...])` and the receiver sees
+ *     `"[object Object],[object Object]"`).
+ *     `null` / `undefined` skip the stringify so nullable `@ValidateNested`
+ *     + `@IsOptional` fields keep working in single-pass flows (where the
+ *     transform runs together with `__getData` before validation).
+ *
+ * Both branches operate on the same value in a single transform call, so
+ * `applyTransforms(data, cls, { groups: ['__getData', '__sendData', '__grpc'] })`
+ * runs the whole gRPC pipeline in one walk: parse (if string), stringify (if
+ * non-null object).
+ *
+ * `isDto: true` is a short-circuit for SDK-side request DTOs that always
+ * arrive as already-stringified JSON.
+ */
 export function AnyType({ isDto }: { isDto?: boolean } = {}) {
     return Transform((object) => {
         if (isDto && typeof object.value === 'string') {
             return JSON.parse(object.value);
         }
 
-        if (object.options.groups?.includes('__sendData')) {
-            return JSON.stringify(object.value);
-        }
-        if (object.options.groups?.includes('__getData')) {
-            if (typeof object.value !== 'string') {
-                return object.value;
-            }
+        const groups = object.options.groups ?? [];
+        let value = object.value;
+
+        if (groups.includes('__getData') && typeof value === 'string') {
             try {
-                return JSON.parse(object.value);
+                value = JSON.parse(value);
             } catch {
-                return object.value;
+                /* keep the raw string */
             }
         }
 
-        return object.value;
+        if (groups.includes('__sendData') && value !== null && value !== undefined) {
+            value = JSON.stringify(value);
+        }
+
+        return value;
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hodfords/nestjs-grpc-helper",
-    "version": "11.4.0-rc.39",
+    "version": "11.4.0-rc.41",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hodfords/nestjs-grpc-helper",
-            "version": "11.4.0-rc.39",
+            "version": "11.4.0-rc.41",
             "license": "UNLICENSED",
             "dependencies": {
                 "@faker-js/faker": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-grpc-helper",
-    "version": "11.4.0-rc.40",
+    "version": "11.4.0-rc.41",
     "description": "A utility for simplifying gRPC integration and communication in NestJS applications",
     "author": "",
     "license": "UNLICENSED",


### PR DESCRIPTION
## Summary

Backport of [`#52`](https://github.com/hodfords-solutions/nestjs-grpc-helper/pull/52) (which shipped on `main` as 11.3.7) onto the 11.4.x-rc line. Folds `@AnyType()`'s two phases (`__getData` parse + `__sendData` stringify) into a single transform fn with a null guard so a paired `nestjs-response` (PR [#37](https://github.com/hodfords-solutions/nestjs-response/pull/37), released as 11.1.5) can do the entire gRPC server-outgoing pipeline in one `applyTransforms` walk.

## Why both lines need this

Downstream apps on the 11.4.x-rc line (e.g. employer-backend) use `SdkExpose` / `SdkFlattenParams` — decorators that only exist on the `next` branch, not on `main`. They can't downgrade to 11.3.x to pick up the fix, so the same change needs to land here.

Concrete blockers when employer-backend tried bumping to `11.3.7`:
- TS errors: `Module '"@hodfords/nestjs-grpc-helper"' has no exported member 'SdkExpose'` (and `'SdkFlattenParams'`) in `apps/planix`, `apps/asset`, `apps/recruitment`, `apps/secret-management`, `apps/work-device`, …
- Runtime: `Cannot find module '@nestjs/microservices/client/constants'` — the 11.3.x line still imports `GRPC_CANCELLED` from a path that was removed in `@nestjs/microservices >= 11.1`.

11.4.0-rc.40 already runs against current `@nestjs/microservices` and ships all the SDK decorators employer-backend needs. Adding the `@AnyType()` fix as 11.4.0-rc.41 unblocks the bump.

## What changed

Identical to PR #52, applied to the 11.4.x-rc source:

```ts
export function AnyType({ isDto }: { isDto?: boolean } = {}) {
    return Transform((object) => {
        if (isDto && typeof object.value === 'string') {
            return JSON.parse(object.value);
        }
        const groups = object.options.groups ?? [];
        let value = object.value;

        if (groups.includes('__getData') && typeof value === 'string') {
            try { value = JSON.parse(value); } catch { /* keep raw */ }
        }
        if (groups.includes('__sendData') && value !== null && value !== undefined) {
            value = JSON.stringify(value);
        }
        return value;
    });
}
```

The existing `any-type.decorator.spec.ts` suite was kept (group-isolated behaviour unchanged) and extended with:
- `single-pass __getData + __sendData` — JSON-string input normalises to a stable wire form; plain object/array stringifies cleanly.
- `null / undefined guard on __sendData` — nullish skips stringify in the combined-groups call AND in the `__sendData`-only SDK-client path.

## Pairs with

- [`hodfords-solutions/nestjs-response#37`](https://github.com/hodfords-solutions/nestjs-response/pull/37) — released as `11.1.5`. Collapses `handleSingleResponse` to a single `applyTransforms({groups: isGrpc ? ['__getData','__sendData','__grpc'] : ['__getData']})` + validate.

## Trade-off — null wire round-trip

The null guard means `null` no longer survives the gRPC wire as `"null"` → `null`. Server `null` now serialises as proto3's default empty string and the receiver's `__getData` returns `""`. Consumers that need to distinguish "no value" from "empty string" should drop nullable `@ValidateNested` from their `@AnyType()` fields or switch to a structured proto type.

## Test plan

- [x] `npx jest lib/decorators/any-type.decorator.spec.ts` — 12/12 pass (4 existing + 8 new).
- [x] `npx jest` — same 2 pre-existing infrastructure failures as unmodified `next` (`custom-grpc.client.spec.ts` and `microservice-document.module.spec.ts` — missing proto files, not related to this change). All other suites pass.
- [x] Lint — same 2 pre-existing unused-import warnings in `sample/main.ts` as unmodified `next`.

## Bump

`11.4.0-rc.40` → `11.4.0-rc.41`.